### PR TITLE
Overhaul and improve readability of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,7 @@ Given a POST request to: `/api/query`
 ```
 
 <details open>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```json
 {
@@ -173,11 +169,7 @@ console.log(response);
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -204,11 +196,7 @@ console.log(response);
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -243,11 +231,7 @@ console.log(response);
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -281,11 +265,7 @@ console.log(response);
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -346,11 +326,7 @@ console.log(response);
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -406,11 +382,7 @@ console.log(response);
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -451,11 +423,7 @@ console.log(response);
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -501,11 +469,7 @@ const response = await $fetch(api, {
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -551,11 +515,7 @@ const response = await $fetch(api, {
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -608,11 +568,7 @@ const response = await $fetch(api, {
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -676,11 +632,7 @@ const response = await $fetch(api, {
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {
@@ -739,11 +691,7 @@ const response = await $fetch(api, {
 ```
 
 <details>
-<summary>
-
-🆗 **Response**
-
-</summary>
+<summary>🆗 Response</summary>
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ return [
 ];
 ```
 
-### Sending POST requests
+### Sending POST Requests
 
 You can use any HTTP request library in your language of choice to make regular POST requests to your `/api/query` endpoint. In this example, we are using [ohmyfetch](https://github.com/unjs/ohmyfetch) (a better fetch API for Node and the browser) and JavaScript to retreive data from our Kirby installation.
 
@@ -150,11 +150,11 @@ console.log(response);
 
 With the query, you can fetch data from anywhere in your Kirby site. You can query fields, pages, files, users, languages, roles and more.
 
-#### Queries without selects
+#### Queries Without Selects
 
 When you don't pass the select option, Kirby will try to come up with the most useful result set for you. This is great for simple queries.
 
-##### Fetching the site title
+##### Fetching the Site Title
 
 ```js
 const response = await $fetch(api, {
@@ -181,7 +181,7 @@ console.log(response);
 
 </details>
 
-##### Fetching a list of page ids
+##### Fetching a List of Page IDs
 
 ```js
 const response = await $fetch(api, {
@@ -214,7 +214,7 @@ console.log(response);
 
 </details>
 
-#### Running field methods
+#### Running Field Methods
 
 Queries can even execute field methods.
 
@@ -247,7 +247,7 @@ console.log(response);
 
 KQL becomes really powerful by its flexible way to control the result set with the select option.
 
-#### Select single properties and fields
+#### Select Single Properties and Fields
 
 To include a property or field in your results, list them as an array. Check out our [reference for available properties](https://getkirby.com/docs/reference) for pages, users, files, etc.
 
@@ -362,7 +362,7 @@ console.log(response);
 
 </details>
 
-#### Using queries for properties and fields
+#### Using Queries for Properties and Fields
 
 Instead of passing true, you can also pass a string query to specify what you want to return for each key in your select object.
 
@@ -405,7 +405,7 @@ console.log(response);
 
 </details>
 
-#### Executing field methods
+#### Executing Field Methods
 
 ```js
 const response = await $fetch(api, {
@@ -446,7 +446,7 @@ console.log(response);
 
 </details>
 
-#### Creating aliases
+#### Creating Aliases
 
 String queries are a perfect way to create aliases or return variations of the same field or property multiple times.
 
@@ -544,7 +544,7 @@ const response = await $fetch(api, {
 
 </details>
 
-#### Subqueries with selects
+#### Subqueries With Selects
 
 You can also pass an object with a `query` and a `select` option
 
@@ -719,7 +719,7 @@ const response = await $fetch(api, {
 
 </details>
 
-### Pagination in subqueries
+### Pagination in Subqueries
 
 Pagination settings also work for subqueries.
 
@@ -746,7 +746,7 @@ const response = await $fetch(api, {
 });
 ```
 
-### Multiple queries in a single call
+### Multiple Queries in a Single Call
 
 With the power of selects and subqueries you can basically query the entire site in a single request
 
@@ -790,11 +790,11 @@ const response = await $fetch(api, {
 });
 ```
 
-### Allowing methods
+### Allowing Methods
 
 KQL is very strict with allowed methods by default. Custom page methods, file methods or model methods are not allowed to make sure you don't miss an important security issue by accident. You can allow additional methods though.
 
-#### Allow list
+#### Allow List
 
 The most straight forward way is to define allowed methods in your config.
 
@@ -812,7 +812,7 @@ return [
 ];
 ```
 
-#### DocBlock comment
+#### DocBlock Comment
 
 You can also add a comment to your methods' doc blocks to allow them:
 
@@ -844,7 +844,7 @@ Kirby::plugin('your-name/your-plugin', [
 ]);
 ```
 
-### Blocking methods
+### Blocking Methods
 
 You can block individual class methods that would normally be accessible by listing them in your config:
 
@@ -862,7 +862,7 @@ return [
 ];
 ```
 
-### Blocking classes
+### Blocking Classes
 
 Sometimes you might want to reduce access to various parts of the system. This can be done by blocking individual methods (see above) or by blocking entire classes.
 
@@ -882,7 +882,7 @@ return [
 
 Now, access to any user is blocked.
 
-### Custom classes and interceptors
+### Custom Classes and Interceptors
 
 If you want to add support for a custom class or a class in Kirby's source that is not supported yet, you can list your own interceptors in your config
 
@@ -940,7 +940,7 @@ class SystemInterceptor extends Kirby\Kql\Interceptors\Interceptor
 
 This custom method can now be used with `kirby.system.isReady` in KQL and will return `yes it is!`
 
-### Unintercepted classes
+### Unintercepted Classes
 
 If you want to fully allow access to an entire class without putting an interceptor in between, you can add the class to the allow list in your config:
 
@@ -958,9 +958,13 @@ return [
 
 This will introduce full access to all public class methods. This can be very risky though and you should avoid this if possible.
 
-### No mutations
+### No Mutations
 
 KQL only offers access to data in your site. It does not support any mutations. All destructive methods are blocked and cannot be accessed in queries.
+
+## Plugins
+
+- [nuxt-kql](https://nuxt-kql.jhnn.dev): A Nuxt 3 module for KQL.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ KQL becomes really powerful by its flexible way to control the result set with t
 
 #### Select single properties and fields
 
-To include a property or field in your results, list them as an array. Check out our reference for available properties for pages, users, files, etc: https://getkirby.com/docs/reference
+To include a property or field in your results, list them as an array. Check out our [reference for available properties](https://getkirby.com/docs/reference) for pages, users, files, etc.
 
 ```js
 const response = await $fetch(api, {

--- a/README.md
+++ b/README.md
@@ -4,72 +4,91 @@ Kirby's Query Language API combines the flexibility of Kirby's data structures, 
 
 The Kirby QL API takes POST requests with standard JSON objects and returns highly customized results that fit your application.
 
-## Demo
+## Playground
 
-You can play in our KQL sandbox here: https://kql.getkirby.com The sandbox is based on the Kirby starterkit.
+You can play in our [KQL sandbox](https://kql.getkirby.com). The sandbox is based on the Kirby starterkit.
+
+> ℹ️ Source code of the playground is [available on GitHub](https://github.com/getkirby/kql.getkirby.com).
 
 ## Example
 
-POST: /api/query
+Given a POST request to: `/api/query``
 
 ```json
 {
-    "query": "page('photography').children",
-    "select": {
-        "url": true,
-        "title": true,
-        "text": "page.text.markdown",
-        "images": {
-            "query": "page.images",
-            "select": {
-                "url": true
-            }
-        }
-    },
-    "pagination": {
-        "limit": 10
+  "query": "page('photography').children",
+  "select": {
+    "url": true,
+    "title": true,
+    "text": "page.text.markdown",
+    "images": {
+      "query": "page.images",
+      "select": {
+        "url": true
+      }
     }
+  },
+  "pagination": {
+    "limit": 10
+  }
 }
 ```
 
-Response:
+<details open>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```json
 {
-    "code": 200,
-    "result": {
-        "data": [
-            {
-                "url": "https://example.com/photography/trees",
-                "title": "Trees",
-                "text": "Lorem <strong>ipsum</strong> …",
-                "images": [
-                    { "url": "https://example.com/media/pages/photography/trees/1353177920-1579007734/cheesy-autumn.jpg" },
-                    { "url": "https://example.com/media/pages/photography/trees/1940579124-1579007734/last-tree-standing.jpg" },
-                    { "url": "https://example.com/media/pages/photography/trees/3506294441-1579007734/monster-trees-in-the-fog.jpg" }
-                ]
-            },
-            {
-                "url": "https://example.com/photography/sky",
-                "title": "Sky",
-                "text": "<h1>Dolor sit amet</h1> …",
-                "images": [
-                    { "url": "https://example.com/media/pages/photography/sky/183363500-1579007734/blood-moon.jpg" },
-                    { "url": "https://example.com/media/pages/photography/sky/3904851178-1579007734/coconut-milkyway.jpg" }
-                ]
-            }
-        ],
-        "pagination": {
-            "page": 1,
-            "pages": 1,
-            "offset": 0,
-            "limit": 10,
-            "total": 2
-        }
-    },
-    "status": "ok"
+  "code": 200,
+  "result": {
+    "data": [
+      {
+        "url": "https://example.com/photography/trees",
+        "title": "Trees",
+        "text": "Lorem <strong>ipsum</strong> …",
+        "images": [
+          {
+            "url": "https://example.com/media/pages/photography/trees/1353177920-1579007734/cheesy-autumn.jpg"
+          },
+          {
+            "url": "https://example.com/media/pages/photography/trees/1940579124-1579007734/last-tree-standing.jpg"
+          },
+          {
+            "url": "https://example.com/media/pages/photography/trees/3506294441-1579007734/monster-trees-in-the-fog.jpg"
+          }
+        ]
+      },
+      {
+        "url": "https://example.com/photography/sky",
+        "title": "Sky",
+        "text": "<h1>Dolor sit amet</h1> …",
+        "images": [
+          {
+            "url": "https://example.com/media/pages/photography/sky/183363500-1579007734/blood-moon.jpg"
+          },
+          {
+            "url": "https://example.com/media/pages/photography/sky/3904851178-1579007734/coconut-milkyway.jpg"
+          }
+        ]
+      }
+    ],
+    "pagination": {
+      "page": 1,
+      "pages": 1,
+      "offset": 0,
+      "limit": 10,
+      "total": 2
+    }
+  },
+  "status": "ok"
 }
 ```
+
+</details>
 
 ## Installation
 
@@ -79,7 +98,7 @@ Response:
 
 ### Composer
 
-```
+```bash
 composer require getkirby/kql
 ```
 
@@ -87,13 +106,11 @@ composer require getkirby/kql
 
 ### API Endpoint
 
-KQL adds a new `query` API endpoint to your Kirby API. (i.e. https://yoursite.com/api/query) The endpoint requires authentication: https://getkirby.com/docs/guide/api/authentication
+KQL adds a new `query` API endpoint to your Kirby API (i.e. `yoursite.com/api/query`). This endpoint [requires authentication](https://getkirby.com/docs/guide/api/authentication).
 
 You can switch off authentication in your config at your own risk:
 
 ```php
-<?php
-
 return [
   'kql' => [
     'auth' => false
@@ -103,26 +120,32 @@ return [
 
 ### Sending POST requests
 
-You can use any HTTP request library in your language of choice to make regular POST requests to your `/api/query` endpoint. In this example, we are using [axios](https://github.com/axios/axios) and Javascript to get data from our Kirby installation.
+You can use any HTTP request library in your language of choice to make regular POST requests to your `/api/query` endpoint. In this example, we are using [ohmyfetch](https://github.com/unjs/ohmyfetch) (a better fetch API for Node and the browser) and JavaScript to retreive data from our Kirby installation.
 
 ```js
-const axios = require("axios")
+import { $fetch } from "ohmyfetch";
 
 const api = "https://yoursite.com/api/query";
-const auth = {
-  username: "apiuser",
-  password: "strong-secret-api-password"
+const username = "apiuser";
+const password = "strong-secret-api-password";
+
+const headers = {
+  Authorization: Buffer.from(`${username}:${password}`).toString("base64"),
 };
 
-const response = await axios.post(api, {
-  query: "page('notes').children",
-  select: {
-    title: true,
-    text: "page.text.kirbytext",
-    slug: true,
-    date: "page.date.toDate('d.m.Y')"
-  }
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "page('notes').children",
+    select: {
+      title: true,
+      text: "page.text.kirbytext",
+      slug: true,
+      date: "page.date.toDate('d.m.Y')",
+    },
+  },
+  headers,
+});
 
 console.log(response);
 ```
@@ -136,15 +159,25 @@ With the query, you can fetch data from anywhere in your Kirby site. You can que
 When you don't pass the select option, Kirby will try to come up with the most useful result set for you. This is great for simple queries.
 
 ##### Fetching the site title
-```js
-const response = await axios.post(api, {
-  query: "site.title",
-}, { auth });
 
-console.log(response.data);
+```js
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "site.title",
+  },
+  headers,
+});
+
+console.log(response);
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -154,16 +187,28 @@ Result:
 }
 ```
 
-##### Fetching a list of page ids
-```js
-const response = await axios.post(api, {
-  query: "site.children"
-}, { auth });
+</details>
 
-console.log(response.data);
+##### Fetching a list of page ids
+
+```js
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "site.children",
+  },
+  headers,
+});
+
+console.log(response);
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -179,19 +224,30 @@ Result:
 }
 ```
 
+</details>
+
 #### Running field methods
 
 Queries can even execute field methods.
 
 ```js
-const response = await axios.post(api, {
-  query: "site.title.upper",
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "site.title.upper",
+  },
+  headers,
+});
 
-console.log(response.data);
+console.log(response);
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -200,6 +256,8 @@ Result:
   status: "ok"
 }
 ```
+
+</details>
 
 ### `select`
 
@@ -210,15 +268,24 @@ KQL becomes really powerful by its flexible way to control the result set with t
 To include a property or field in your results, list them as an array. Check out our reference for available properties for pages, users, files, etc: https://getkirby.com/docs/reference
 
 ```js
-const response = await axios.post(api, {
-  query: "site.children",
-  select: ["title", "url"]
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "site.children",
+    select: ["title", "url"],
+  },
+  headers,
+});
 
-console.log(response.data);
+console.log(response);
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -258,21 +325,32 @@ Result:
 }
 ```
 
+</details>
+
 You can also use the object notation and pass true for each key/property you want to include.
 
 ```js
-const response = await axios.post(api, {
-  query: "site.children",
-  select: {
-    title: true,
-    url: true
-  }
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "site.children",
+    select: {
+      title: true,
+      url: true,
+    },
+  },
+  headers,
+});
 
-console.log(response.data);
+console.log(response);
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -306,22 +384,33 @@ Result:
 }
 ```
 
+</details>
+
 #### Using queries for properties and fields
 
 Instead of passing true, you can also pass a string query to specify what you want to return for each key in your select object.
 
 ```js
-const response = await axios.post(api, {
-  query: "site.children",
-  select: {
-    title: "page.title"
-  }
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "site.children",
+    select: {
+      title: "page.title",
+    },
+  },
+  headers,
+});
 
-console.log(response.data);
+console.log(response);
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -342,19 +431,31 @@ Result:
 }
 ```
 
-#### Executing field methods
-```js
-const response = await axios.post(api, {
-  query: "site.children",
-  select: {
-    title: "page.title.upper"
-  }
-}, { auth });
+</details>
 
-console.log(response.data);
+#### Executing field methods
+
+```js
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "site.children",
+    select: {
+      title: "page.title.upper",
+    },
+  },
+  headers,
+});
+
+console.log(response);
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -375,25 +476,36 @@ Result:
 }
 ```
 
+</details>
+
 #### Creating aliases
 
 String queries are a perfect way to create aliases or return variations of the same field or property multiple times.
 
 ```js
-const response = await axios.post(api, {
-  query: "page('notes').children",
-  select: {
-    title: "page.title",
-    upperCaseTitle: "page.title.upper",
-    lowerCaseTitle: "page.title.lower",
-    guid: "page.id",
-    date: "page.date.toDate('d.m.Y'),
-    timestamp: "page.date.toTimestamp"
-  }
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "page('notes').children",
+    select: {
+      title: "page.title",
+      upperCaseTitle: "page.title.upper",
+      lowerCaseTitle: "page.title.lower",
+      guid: "page.id",
+      date: "page.date.toDate('d.m.Y')",
+      timestamp: "page.date.toTimestamp",
+    },
+  },
+  headers,
+});
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -418,21 +530,32 @@ Result:
 }
 ```
 
+</details>
+
 #### Subqueries
 
 With such string queries you can of course also include nested data
 
 ```js
-const response = await axios.post(api, {
-  query: "page('photography').children",
-  select: {
-    title: "page.title",
-    images: "page.images"
-  }
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "page('photography').children",
+    select: {
+      title: "page.title",
+      images: "page.images",
+    },
+  },
+  headers,
+});
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -459,26 +582,37 @@ Result:
 }
 ```
 
+</details>
+
 #### Subqueries with selects
 
 You can also pass an object with a `query` and a `select` option
 
 ```js
-const response = await axios.post(api, {
-  query: "page('photography').children",
-  select: {
-    title: "page.title",
-    images: {
-      query: "page.images",
-      select: {
-        filename: true
-      }
-    }
-  }
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "page('photography').children",
+    select: {
+      title: "page.title",
+      images: {
+        query: "page.images",
+        select: {
+          filename: true,
+        },
+      },
+    },
+  },
+  headers,
+});
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -515,6 +649,8 @@ Result:
 }
 ```
 
+</details>
+
 ### Pagination
 
 Whenever you query a collection (pages, files, users, roles, languages) you can limit the resultset and also paginate through entries. You've probably already seen the pagination object in the results above. It is included in all results for collections, even if you didn't specify any pagination settings.
@@ -524,18 +660,27 @@ Whenever you query a collection (pages, files, users, roles, languages) you can 
 You can specify a custom limit with the limit option. The default limit for collections is 100 entries.
 
 ```js
-const response = await axios.post(api, {
-  query: "page('notes').children",
-  pagination: {
-    limit: 5,
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "page('notes').children",
+    pagination: {
+      limit: 5,
+    },
+    select: {
+      title: "page.title",
+    },
   },
-  select: {
-    title: "page.title"
-  }
-}, { auth });
+  headers,
+});
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -570,24 +715,35 @@ Result:
 }
 ```
 
+</details>
+
 #### `page`
 
 You can jump to any page in the resultset with the `page` option.
 
 ```js
-const response = await axios.post(api, {
-  query: "page('notes').children",
-  pagination: {
-    page: 2,
-    limit: 5
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "page('notes').children",
+    pagination: {
+      page: 2,
+      limit: 5,
+    },
+    select: {
+      title: "page.title",
+    },
   },
-  select: {
-    title: "page.title"
-  }
-}, { auth });
+  headers,
+});
 ```
 
-Result:
+<details>
+<summary>
+
+🆗 **Response**
+
+</summary>
 
 ```js
 {
@@ -613,27 +769,33 @@ Result:
 }
 ```
 
+</details>
+
 ### Pagination in subqueries
 
 Pagination settings also work for subqueries.
 
 ```js
-const response = await axios.post(api, {
-  query: "page('photography').children",
-  select: {
-    title: "page.title",
-    images: {
-      query: "page.images",
-      pagination: {
-        page: 2,
-        limit: 5
-      }
-      select: {
-        filename: true
-      }
-    }
-  }
-}, { auth });
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "page('photography').children",
+    select: {
+      title: "page.title",
+      images: {
+        query: "page.images",
+        pagination: {
+          page: 2,
+          limit: 5,
+        },
+        select: {
+          filename: true,
+        },
+      },
+    },
+  },
+  headers,
+});
 ```
 
 ### Multiple queries in a single call
@@ -641,39 +803,43 @@ const response = await axios.post(api, {
 With the power of selects and subqueries you can basically query the entire site in a single request
 
 ```js
-const response = await axios.post(api, {
-  query: "site",
-  select: {
-    title: "site.title",
-    url: "site.url",
-    notes: {
-      query: "page('notes').children.listed",
-      select: {
-        title: true,
-        url: true,
-        date: "page.date.toDate('d.m.Y')"
-        text: "page.text.kirbytext"
-      }
+const response = await $fetch(api, {
+  method: "post",
+  body: {
+    query: "site",
+    select: {
+      title: "site.title",
+      url: "site.url",
+      notes: {
+        query: "page('notes').children.listed",
+        select: {
+          title: true,
+          url: true,
+          date: "page.date.toDate('d.m.Y')",
+          text: "page.text.kirbytext",
+        },
+      },
+      photography: {
+        query: "page('photography').children.listed",
+        select: {
+          title: true,
+          images: {
+            query: "page.images",
+            select: {
+              url: true,
+              alt: true,
+              caption: "file.caption.kirbytext",
+            },
+          },
+        },
+      },
+      about: {
+        text: "page.text.kirbytext",
+      },
     },
-    photography: {
-      query: "page('photography').children.listed",
-      select: {
-        title: true,
-        images: {
-          query: "page.images",
-          select: {
-             url: true,
-             alt: true,
-             caption: "file.caption.kirbytext"
-          }
-        }
-      }
-    },
-    about: {
-      text: "page.text.kirbytext"
-    }
-  }
-}, { auth });
+  },
+  headers,
+});
 ```
 
 ### Allowing methods
@@ -848,10 +1014,6 @@ This will introduce full access to all public class methods. This can be very ri
 
 KQL only offers access to data in your site. It does not support any mutations. All destructive methods are blocked and cannot be accessed in queries.
 
-## Credits
-
-[Bastian Allgeier](https://getkirby.com)
-
 ## License
 
-<http://www.opensource.org/licenses/mit-license.php>
+[MIT](./LICENSE) License © 2020-2022 [Bastian Allgeier](https://getkirby.com)

--- a/README.md
+++ b/README.md
@@ -799,8 +799,6 @@ KQL is very strict with allowed methods by default. Custom page methods, file me
 The most straight forward way is to define allowed methods in your config.
 
 ```php
-<?php
-
 return [
   'kql' => [
     'methods' => [
@@ -849,8 +847,6 @@ Kirby::plugin('your-name/your-plugin', [
 You can block individual class methods that would normally be accessible by listing them in your config:
 
 ```php
-<?php
-
 return [
   'kql' => [
     'methods' => [
@@ -867,8 +863,6 @@ return [
 Sometimes you might want to reduce access to various parts of the system. This can be done by blocking individual methods (see above) or by blocking entire classes.
 
 ```php
-<?php
-
 return [
   'kql' => [
     'classes' => [
@@ -887,8 +881,6 @@ Now, access to any user is blocked.
 If you want to add support for a custom class or a class in Kirby's source that is not supported yet, you can list your own interceptors in your config
 
 ```php
-<?php
-
 return [
   'kql' => [
     'interceptors' => [
@@ -901,8 +893,6 @@ return [
 You can put the class for such a custom interceptor in a plugin for example.
 
 ```php
-<?php
-
 class SystemInterceptor extends Kirby\Kql\Interceptors\Interceptor
 {
   public const CLASS_ALIAS = 'system';
@@ -925,8 +915,6 @@ Interceptor classes are pretty straight forward. With the CLASS_ALIAS you can gi
 The `allowedMethods` method must return an array of all methods that can be access for this object. In addition to that you can also create your own custom methods in an interceptor that will then become available in KQL.
 
 ```php
-<?php
-
 class SystemInterceptor extends Kirby\Kql\Interceptors\Interceptor
 {
   ...

--- a/README.md
+++ b/README.md
@@ -910,7 +910,7 @@ class SystemInterceptor extends Kirby\Kql\Interceptors\Interceptor
 }
 ```
 
-Interceptor classes are pretty straight forward. With the CLASS_ALIAS you can give objects with that class a short name for KQL queries. The `$toArray` property lists all methods that should be rendered if you don't run a subquery. I.e. in this case `kirby.system` would render an array with the `isInstallable` value.
+Interceptor classes are pretty straight forward. With the `CLASS_ALIAS` you can give objects with that class a short name for KQL queries. The `$toArray` property lists all methods that should be rendered if you don't run a subquery. I.e. in this case `kirby.system` would render an array with the `isInstallable` value.
 
 The `allowedMethods` method must return an array of all methods that can be access for this object. In addition to that you can also create your own custom methods in an interceptor that will then become available in KQL.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can play in our [KQL sandbox](https://kql.getkirby.com). The sandbox is base
 
 ## Example
 
-Given a POST request to: `/api/query``
+Given a POST request to: `/api/query`
 
 ```json
 {


### PR DESCRIPTION
## What Is This?

This PR enhances the README's readability:

- Use `<details>` element to hide responses, which shortens the whole document.
- Replace `axios` with `ohmyfetch`
  - It is pretty outdated and bulky by not using the Fetch standard. `ohmyfetch` is a thin wrapper around `fetch` and the basis for all requests in Nuxt 3. Thus, not one of the many fetch-wrapping libraries, but a well-tested one. It works in the browser and node.
- It is time to drop CJS in favor of ESM.
- Prettier is used to format the JS and JSON snippets.

👉 [Preview of the improved README](https://github.com/johannschopplich/kql#readme)

## `<details>` Response Example

<details>
<summary>🆗 Response</summary>

```js
{
  code: 200,
  result: "Kirby Starterkit",
  status: "ok"
}
```

</details>


## Other Notes

This also closes https://github.com/getkirby/kql/issues/34.