### PR TITLE
Fix typo in Unintercepted Classes config

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,7 +936,7 @@ If you want to fully allow access to an entire class without putting an intercep
 return [
   'kql' => [
     'classes' => [
-      'allow' => [
+      'allowed' => [
         'Kirby\Cms\System'
       ]
     ]


### PR DESCRIPTION
Noticed the example config object had a typo since the option uses allowed instead of allow

https://github.com/getkirby/kql/blob/main/src/Kql/Interceptor.php#L260